### PR TITLE
"fixed" types for port number and window size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,12 @@ if(UNIX)
         if(NOT CLSOCKET_DEP_ONLY)
             install(TARGETS clsocket-example DESTINATION bin)
         endif()
+
+        ADD_EXECUTABLE(querydaytime-example examples/QueryDayTime.cpp)
+        TARGET_LINK_LIBRARIES(querydaytime-example clsocket)
+
+        ADD_EXECUTABLE(echoserver-example examples/EchoServer.cpp)
+        TARGET_LINK_LIBRARIES(echoserver-example clsocket)
     endif()
 endif()
 

--- a/README
+++ b/README
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
     // Create a connection to the time server so that data can be sent
     // and received.
     //--------------------------------------------------------------------------
-    if (socket.Open((const uint8 *)"time-C.timefreq.bldrdoc.gov", 13))
+    if (socket.Open("time-C.timefreq.bldrdoc.gov", 13))
     {
         //----------------------------------------------------------------------
         // Send a requtest the server requesting the current time.
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
     //--------------------------------------------------------------------------
     socket.Initialize();
 
-    socket.Listen((const uint8 *)"127.0.0.1", 6789);
+    socket.Listen("127.0.0.1", 6789);
 
     while (true)
     {
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
                 //------------------------------------------------------------------
                 // Send response to client and close connection to the client.
                 //------------------------------------------------------------------
-                pClient->Send((const uint8 *)pClient->GetData(), pClient->GetBytesReceived());
+                pClient->Send( pClient->GetData(), pClient->GetBytesReceived() );
                 pClient->Close();
             }
 

--- a/examples/EchoServer.cpp
+++ b/examples/EchoServer.cpp
@@ -1,0 +1,44 @@
+
+#include "PassiveSocket.h"       // Include header for active socket object definition
+
+#define MAX_PACKET 4096 
+
+int main(int argc, char **argv)
+{
+    CPassiveSocket socket;
+    CActiveSocket *pClient = NULL;
+
+    //--------------------------------------------------------------------------
+    // Initialize our socket object 
+    //--------------------------------------------------------------------------
+    socket.Initialize();
+
+    socket.Listen("127.0.0.1", 6789);
+
+    while (true)
+    {
+        if ((pClient = socket.Accept()) != NULL)
+        {
+            //----------------------------------------------------------------------
+            // Receive request from the client.
+            //----------------------------------------------------------------------
+            if (pClient->Receive(MAX_PACKET))
+            {
+                //------------------------------------------------------------------
+                // Send response to client and close connection to the client.
+                //------------------------------------------------------------------
+                pClient->Send( pClient->GetData(), pClient->GetBytesReceived() );
+                pClient->Close();
+            }
+
+            delete pClient;
+        }
+    }
+
+    //-----------------------------------------------------------------------------
+    // Receive request from the client.
+    //-----------------------------------------------------------------------------
+    socket.Close();
+
+    return 1;
+}

--- a/examples/QueryDayTime.cpp
+++ b/examples/QueryDayTime.cpp
@@ -1,0 +1,44 @@
+
+#include <string.h>
+#include "ActiveSocket.h"       // Include header for active socket object definition
+
+int main(int argc, char **argv)
+{
+    CActiveSocket socket;       // Instantiate active socket object (defaults to TCP).
+    char          time[50];
+
+    memset(&time, 0, 50);
+
+    //--------------------------------------------------------------------------
+    // Initialize our socket object 
+    //--------------------------------------------------------------------------
+    socket.Initialize();
+
+    //--------------------------------------------------------------------------
+    // Create a connection to the time server so that data can be sent
+    // and received.
+    //--------------------------------------------------------------------------
+    if (socket.Open("time-C.timefreq.bldrdoc.gov", 13))
+    {
+        //----------------------------------------------------------------------
+        // Send a requtest the server requesting the current time.
+        //----------------------------------------------------------------------
+        if (socket.Send((const uint8 *)"\n", 1))
+        {
+            //----------------------------------------------------------------------
+            // Receive response from the server.
+            //----------------------------------------------------------------------
+            socket.Receive(49);
+            memcpy(&time, socket.GetData(), 49);
+            printf("%s\n", time);
+
+            //----------------------------------------------------------------------
+            // Close the connection.
+            //----------------------------------------------------------------------
+            socket.Close();
+        }
+    }
+
+
+    return 1;
+}

--- a/examples/RecvAsync.cpp
+++ b/examples/RecvAsync.cpp
@@ -1,6 +1,16 @@
 #include <pthread.h>
 #include "PassiveSocket.h"
 
+#ifdef WIN32
+#include <windows.h>
+
+  // usually defined with #include <unistd.h>
+  static void sleep( unsigned int seconds )
+  {
+    Sleep( seconds * 1000 );
+  }
+#endif
+
 #define MAX_PACKET  4096
 #define TEST_PACKET "Test Packet"
 
@@ -21,7 +31,7 @@ void *CreateTCPEchoServer(void *param)
     int            nBytesReceived = 0;
 
     socket.Initialize();
-    socket.Listen((const uint8 *)pData->pszServerAddr, pData->nPort);
+    socket.Listen(pData->pszServerAddr, pData->nPort);
 
     if ((pClient = socket.Accept()) != NULL)
     {
@@ -61,7 +71,7 @@ int main(int argc, char **argv)
     client.Initialize();
     client.SetNonblocking();
 
-    if (client.Open((uint8 *)"127.0.0.1", 6789))
+    if (client.Open("127.0.0.1", 6789))
     {
         if (client.Send((uint8 *)TEST_PACKET, strlen(TEST_PACKET)))
         {

--- a/examples/RecvAsync.cpp
+++ b/examples/RecvAsync.cpp
@@ -6,10 +6,10 @@
 
 struct thread_data
 {
-    char     *pszServerAddr;
-    short int nPort;
-    int       nNumBytesToReceive;
-    int       nTotalPayloadSize;
+    const char *pszServerAddr;
+    short int   nPort;
+    int         nNumBytesToReceive;
+    int         nTotalPayloadSize;
 };
 
 
@@ -79,11 +79,11 @@ int main(int argc, char **argv)
                     bytesReceived += numBytes;
                     memset(result, 0, 1024);
                     memcpy(result, client.GetData(), numBytes);
-                    printf("received: %s\n", result);
+                    printf("received %d bytes: '%s'\n", numBytes, result);
                 }
                 else
                 {
-                    printf("Recevied %d bytes\n", numBytes);
+                    printf("Received %d bytes\n", numBytes);
                 }
             }
         }

--- a/src/ActiveSocket.cpp
+++ b/src/ActiveSocket.cpp
@@ -51,7 +51,7 @@ CActiveSocket::CActiveSocket(CSocketType nType) : CSimpleSocket(nType)
 // ConnectTCP() -
 //
 //------------------------------------------------------------------------------
-bool CActiveSocket::ConnectTCP(const uint8 *pAddr, uint16 nPort)
+bool CActiveSocket::ConnectTCP(const char *pAddr, uint16 nPort)
 {
     bool           bRetVal = false;
     struct in_addr stIpAddress;
@@ -131,7 +131,7 @@ bool CActiveSocket::ConnectTCP(const uint8 *pAddr, uint16 nPort)
 // ConnectUDP() -
 //
 //------------------------------------------------------------------------------
-bool CActiveSocket::ConnectUDP(const uint8 *pAddr, uint16 nPort)
+bool CActiveSocket::ConnectUDP(const char *pAddr, uint16 nPort)
 {
     bool           bRetVal = false;
     struct in_addr stIpAddress;
@@ -190,7 +190,7 @@ bool CActiveSocket::ConnectUDP(const uint8 *pAddr, uint16 nPort)
 // ConnectRAW() -
 //
 //------------------------------------------------------------------------------
-bool CActiveSocket::ConnectRAW(const uint8 *pAddr, uint16 nPort)
+bool CActiveSocket::ConnectRAW(const char *pAddr, uint16 nPort)
 {
     bool           bRetVal = false;
     struct in_addr stIpAddress;
@@ -249,7 +249,7 @@ bool CActiveSocket::ConnectRAW(const uint8 *pAddr, uint16 nPort)
 // Open() - Create a connection to a specified address on a specified port
 //
 //------------------------------------------------------------------------------
-bool CActiveSocket::Open(const uint8 *pAddr, uint16 nPort)
+bool CActiveSocket::Open(const char *pAddr, uint16 nPort)
 {
     bool bRetVal = false;
 

--- a/src/ActiveSocket.cpp
+++ b/src/ActiveSocket.cpp
@@ -51,7 +51,7 @@ CActiveSocket::CActiveSocket(CSocketType nType) : CSimpleSocket(nType)
 // ConnectTCP() -
 //
 //------------------------------------------------------------------------------
-bool CActiveSocket::ConnectTCP(const uint8 *pAddr, int16 nPort)
+bool CActiveSocket::ConnectTCP(const uint8 *pAddr, uint16 nPort)
 {
     bool           bRetVal = false;
     struct in_addr stIpAddress;
@@ -131,7 +131,7 @@ bool CActiveSocket::ConnectTCP(const uint8 *pAddr, int16 nPort)
 // ConnectUDP() -
 //
 //------------------------------------------------------------------------------
-bool CActiveSocket::ConnectUDP(const uint8 *pAddr, int16 nPort)
+bool CActiveSocket::ConnectUDP(const uint8 *pAddr, uint16 nPort)
 {
     bool           bRetVal = false;
     struct in_addr stIpAddress;
@@ -190,7 +190,7 @@ bool CActiveSocket::ConnectUDP(const uint8 *pAddr, int16 nPort)
 // ConnectRAW() -
 //
 //------------------------------------------------------------------------------
-bool CActiveSocket::ConnectRAW(const uint8 *pAddr, int16 nPort)
+bool CActiveSocket::ConnectRAW(const uint8 *pAddr, uint16 nPort)
 {
     bool           bRetVal = false;
     struct in_addr stIpAddress;
@@ -249,7 +249,7 @@ bool CActiveSocket::ConnectRAW(const uint8 *pAddr, int16 nPort)
 // Open() - Create a connection to a specified address on a specified port
 //
 //------------------------------------------------------------------------------
-bool CActiveSocket::Open(const uint8 *pAddr, int16 nPort)
+bool CActiveSocket::Open(const uint8 *pAddr, uint16 nPort)
 {
     bool bRetVal = false;
 

--- a/src/ActiveSocket.h
+++ b/src/ActiveSocket.h
@@ -68,20 +68,20 @@ public:
     ///  @param pAddr specifies the destination address to connect.
     ///  @param nPort specifies the destination port.
     ///  @return true if successful connection made, otherwise false.
-    virtual bool Open(const uint8 *pAddr, uint16 nPort);
+    virtual bool Open(const char *pAddr, uint16 nPort);
 
 private:
     /// Utility function used to create a TCP connection, called from Open().
     ///  @return true if successful connection made, otherwise false.
-    bool ConnectTCP(const uint8 *pAddr, uint16 nPort);
+    bool ConnectTCP(const char *pAddr, uint16 nPort);
 
     /// Utility function used to create a UDP connection, called from Open().
     ///  @return true if successful connection made, otherwise false.
-    bool ConnectUDP(const uint8 *pAddr, uint16 nPort);
+    bool ConnectUDP(const char *pAddr, uint16 nPort);
 
     /// Utility function used to create a RAW connection, called from Open().
     ///  @return true if successful connection made, otherwise false.
-    bool ConnectRAW(const uint8 *pAddr, uint16 nPort);
+    bool ConnectRAW(const char *pAddr, uint16 nPort);
 
 private:
     struct hostent *m_pHE;

--- a/src/ActiveSocket.h
+++ b/src/ActiveSocket.h
@@ -68,20 +68,20 @@ public:
     ///  @param pAddr specifies the destination address to connect.
     ///  @param nPort specifies the destination port.
     ///  @return true if successful connection made, otherwise false.
-    virtual bool Open(const uint8 *pAddr, int16 nPort);
+    virtual bool Open(const uint8 *pAddr, uint16 nPort);
 
 private:
     /// Utility function used to create a TCP connection, called from Open().
     ///  @return true if successful connection made, otherwise false.
-    bool ConnectTCP(const uint8 *pAddr, int16 nPort);
+    bool ConnectTCP(const uint8 *pAddr, uint16 nPort);
 
     /// Utility function used to create a UDP connection, called from Open().
     ///  @return true if successful connection made, otherwise false.
-    bool ConnectUDP(const uint8 *pAddr, int16 nPort);
+    bool ConnectUDP(const uint8 *pAddr, uint16 nPort);
 
     /// Utility function used to create a RAW connection, called from Open().
     ///  @return true if successful connection made, otherwise false.
-    bool ConnectRAW(const uint8 *pAddr, int16 nPort);
+    bool ConnectRAW(const uint8 *pAddr, uint16 nPort);
 
 private:
     struct hostent *m_pHE;

--- a/src/Host.h
+++ b/src/Host.h
@@ -173,7 +173,7 @@ extern "C"
 #define WRITEV(a,b,c)          Writev(b, c)
 #define GETSOCKOPT(a,b,c,d,e)  getsockopt(a,b,c,(char *)d, (int *)e)
 #define SETSOCKOPT(a,b,c,d,e)  setsockopt(a,b,c,(char *)d, (int)e)
-#define GETHOSTBYNAME(a)       gethostbyname((const char *)a)
+#define GETHOSTBYNAME(a)       gethostbyname(a)
 #endif
 
 #if defined(_LINUX) || defined(_DARWIN)
@@ -196,7 +196,7 @@ extern "C"
 #define WRITEV(a,b,c)          writev(a, b, c)
 #define GETSOCKOPT(a,b,c,d,e)  getsockopt((int)a,(int)b,(int)c,(void *)d,(socklen_t *)e)
 #define SETSOCKOPT(a,b,c,d,e)  setsockopt((int)a,(int)b,(int)c,(const void *)d,(int)e)
-#define GETHOSTBYNAME(a)       gethostbyname((const char *)a)
+#define GETHOSTBYNAME(a)       gethostbyname(a)
 #endif
 
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -103,9 +103,16 @@ extern "C"
 #endif
 
 #ifdef WIN32
-  #define UINT8_MAX  (UCHAR_MAX)
-  #define UINT16_MAX (USHRT_MAX)
-  #define UINT32_MAX (ULONG_MAX)
+
+  #ifndef UINT8_MAX
+    #define UINT8_MAX  (UCHAR_MAX)
+  #endif
+  #ifndef UINT16_MAX
+    #define UINT16_MAX (USHRT_MAX)
+  #endif
+  #ifndef UINT32_MAX
+    #define UINT32_MAX (ULONG_MAX)
+  #endif
 
   #if __WORDSIZE == 64
     #define SIZE_MAX (18446744073709551615UL)

--- a/src/PassiveSocket.cpp
+++ b/src/PassiveSocket.cpp
@@ -48,7 +48,7 @@ CPassiveSocket::CPassiveSocket(CSocketType nType) : CSimpleSocket(nType)
 {
 }
 
-bool CPassiveSocket::BindMulticast(const uint8 *pInterface, const uint8 *pGroup, int16 nPort)
+bool CPassiveSocket::BindMulticast(const uint8 *pInterface, const uint8 *pGroup, uint16 nPort)
 {
     bool           bRetVal = false;
 #ifdef WIN32
@@ -130,7 +130,7 @@ bool CPassiveSocket::BindMulticast(const uint8 *pInterface, const uint8 *pGroup,
 // Listen() -
 //
 //------------------------------------------------------------------------------
-bool CPassiveSocket::Listen(const uint8 *pAddr, int16 nPort, int32 nConnectionBacklog)
+bool CPassiveSocket::Listen(const uint8 *pAddr, uint16 nPort, int32 nConnectionBacklog)
 {
     bool           bRetVal = false;
 #ifdef WIN32

--- a/src/PassiveSocket.cpp
+++ b/src/PassiveSocket.cpp
@@ -48,7 +48,7 @@ CPassiveSocket::CPassiveSocket(CSocketType nType) : CSimpleSocket(nType)
 {
 }
 
-bool CPassiveSocket::BindMulticast(const uint8 *pInterface, const uint8 *pGroup, uint16 nPort)
+bool CPassiveSocket::BindMulticast(const char *pInterface, const char *pGroup, uint16 nPort)
 {
     bool           bRetVal = false;
 #ifdef WIN32
@@ -73,13 +73,13 @@ bool CPassiveSocket::BindMulticast(const uint8 *pInterface, const uint8 *pGroup,
     // If no IP Address (interface ethn) is supplied, or the loop back is
     // specified then bind to any interface, else bind to specified interface.
     //--------------------------------------------------------------------------
-    if ((pInterface == NULL) || (!strlen((const char *)pInterface)))
+    if ((pInterface == NULL) || (!strlen(pInterface)))
     {
         m_stMulticastGroup.sin_addr.s_addr = htonl(INADDR_ANY);
     }
     else
     {
-        if ((inAddr = inet_addr((const char *)pInterface)) != INADDR_NONE)
+        if ((inAddr = inet_addr(pInterface)) != INADDR_NONE)
         {
             m_stMulticastGroup.sin_addr.s_addr = inAddr;
         }
@@ -93,7 +93,7 @@ bool CPassiveSocket::BindMulticast(const uint8 *pInterface, const uint8 *pGroup,
         //----------------------------------------------------------------------
         // Join the multicast group
         //----------------------------------------------------------------------
-        m_stMulticastRequest.imr_multiaddr.s_addr = inet_addr((const char *)pGroup);
+        m_stMulticastRequest.imr_multiaddr.s_addr = inet_addr(pGroup);
         m_stMulticastRequest.imr_interface.s_addr = m_stMulticastGroup.sin_addr.s_addr;
 
         if (SETSOCKOPT(m_socket, IPPROTO_IP, IP_ADD_MEMBERSHIP,
@@ -130,7 +130,7 @@ bool CPassiveSocket::BindMulticast(const uint8 *pInterface, const uint8 *pGroup,
 // Listen() -
 //
 //------------------------------------------------------------------------------
-bool CPassiveSocket::Listen(const uint8 *pAddr, uint16 nPort, int32 nConnectionBacklog)
+bool CPassiveSocket::Listen(const char *pAddr, uint16 nPort, int32 nConnectionBacklog)
 {
     bool           bRetVal = false;
 #ifdef WIN32
@@ -160,13 +160,13 @@ bool CPassiveSocket::Listen(const uint8 *pAddr, uint16 nPort, int32 nConnectionB
     // If no IP Address (interface ethn) is supplied, or the loop back is
     // specified then bind to any interface, else bind to specified interface.
     //--------------------------------------------------------------------------
-    if ((pAddr == NULL) || (!strlen((const char *)pAddr)))
+    if ((pAddr == NULL) || (!strlen(pAddr)))
     {
         m_stServerSockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
     }
     else
     {
-        if ((inAddr = inet_addr((const char *)pAddr)) != INADDR_NONE)
+        if ((inAddr = inet_addr(pAddr)) != INADDR_NONE)
         {
             m_stServerSockaddr.sin_addr.s_addr = inAddr;
         }

--- a/src/PassiveSocket.h
+++ b/src/PassiveSocket.h
@@ -82,7 +82,7 @@ public:
     ///      condiitions will be set: CPassiveSocket::SocketAddressInUse, CPassiveSocket::SocketProtocolError,
     ///      CPassiveSocket::SocketInvalidSocket.  The following socket errors are for Linux/Unix
     ///      derived systems only: CPassiveSocket::SocketInvalidSocketBuffer
-    bool BindMulticast(const uint8 *pInterface, const uint8 *pGroup, uint16 nPort);
+    bool BindMulticast(const char *pInterface, const char *pGroup, uint16 nPort);
 
     /// Create a listening socket at local ip address 'x.x.x.x' or 'localhost'
     /// if pAddr is NULL on port nPort.
@@ -95,7 +95,7 @@ public:
     ///      conditions will be set: CPassiveSocket::SocketAddressInUse, CPassiveSocket::SocketProtocolError,
     ///      CPassiveSocket::SocketInvalidSocket.  The following socket errors are for Linux/Unix
     ///      derived systems only: CPassiveSocket::SocketInvalidSocketBuffer
-    virtual bool Listen(const uint8 *pAddr, uint16 nPort, int32 nConnectionBacklog = 30000);
+    virtual bool Listen(const char *pAddr, uint16 nPort, int32 nConnectionBacklog = 30000);
 
     /// Attempts to send a block of data on an established connection.
     /// @param pBuf block of data to be sent.

--- a/src/PassiveSocket.h
+++ b/src/PassiveSocket.h
@@ -82,7 +82,7 @@ public:
     ///      condiitions will be set: CPassiveSocket::SocketAddressInUse, CPassiveSocket::SocketProtocolError,
     ///      CPassiveSocket::SocketInvalidSocket.  The following socket errors are for Linux/Unix
     ///      derived systems only: CPassiveSocket::SocketInvalidSocketBuffer
-    bool BindMulticast(const uint8 *pInterface, const uint8 *pGroup, int16 nPort);
+    bool BindMulticast(const uint8 *pInterface, const uint8 *pGroup, uint16 nPort);
 
     /// Create a listening socket at local ip address 'x.x.x.x' or 'localhost'
     /// if pAddr is NULL on port nPort.
@@ -92,10 +92,10 @@ public:
     ///  @param nConnectionBacklog specifies connection queue backlog (default 30,000)
     ///  @return true if a listening socket was created.
     ///      If not successful, the false is returned and one of the following error
-    ///      condiitions will be set: CPassiveSocket::SocketAddressInUse, CPassiveSocket::SocketProtocolError,
+    ///      conditions will be set: CPassiveSocket::SocketAddressInUse, CPassiveSocket::SocketProtocolError,
     ///      CPassiveSocket::SocketInvalidSocket.  The following socket errors are for Linux/Unix
     ///      derived systems only: CPassiveSocket::SocketInvalidSocketBuffer
-    virtual bool Listen(const uint8 *pAddr, int16 nPort, int32 nConnectionBacklog = 30000);
+    virtual bool Listen(const uint8 *pAddr, uint16 nPort, int32 nConnectionBacklog = 30000);
 
     /// Attempts to send a block of data on an established connection.
     /// @param pBuf block of data to be sent.

--- a/src/SimpleSocket.cpp
+++ b/src/SimpleSocket.cpp
@@ -276,7 +276,7 @@ int32 CSimpleSocket::GetSocketDscp(void)
 // GetWindowSize()
 //
 //------------------------------------------------------------------------------
-uint16 CSimpleSocket::GetWindowSize(uint32 nOptionName)
+uint32 CSimpleSocket::GetWindowSize(uint32 nOptionName)
 {
     uint32 nTcpWinSize = 0;
 
@@ -307,7 +307,7 @@ uint16 CSimpleSocket::GetWindowSize(uint32 nOptionName)
 // SetWindowSize()
 //
 //------------------------------------------------------------------------------
-uint16 CSimpleSocket::SetWindowSize(uint32 nOptionName, uint32 nWindowSize)
+uint32 CSimpleSocket::SetWindowSize(uint32 nOptionName, uint32 nWindowSize)
 {
     uint32 nRetVal = 0;
 
@@ -324,7 +324,7 @@ uint16 CSimpleSocket::SetWindowSize(uint32 nOptionName, uint32 nWindowSize)
         SetSocketError(CSimpleSocket::SocketInvalidSocket);
     }
 
-    return (uint16)nWindowSize;
+    return nWindowSize;
 }
 
 

--- a/src/SimpleSocket.cpp
+++ b/src/SimpleSocket.cpp
@@ -164,7 +164,7 @@ bool CSimpleSocket::Initialize()
 // BindInterface()
 //
 //------------------------------------------------------------------------------
-bool CSimpleSocket::BindInterface(uint8 *pInterface)
+bool CSimpleSocket::BindInterface(const char *pInterface)
 {
     bool           bRetVal = false;
     struct in_addr stInterfaceAddr;
@@ -173,7 +173,7 @@ bool CSimpleSocket::BindInterface(uint8 *pInterface)
     {
         if (pInterface)
         {
-            stInterfaceAddr.s_addr= inet_addr((const char *)pInterface);
+            stInterfaceAddr.s_addr= inet_addr(pInterface);
             if (SETSOCKOPT(m_socket, IPPROTO_IP, IP_MULTICAST_IF, &stInterfaceAddr, sizeof(stInterfaceAddr)) == SocketSuccess)
             {
                 bRetVal = true;

--- a/src/SimpleSocket.h
+++ b/src/SimpleSocket.h
@@ -215,10 +215,13 @@ public:
 
     /// Attempts to receive a block of data on an established connection.
     /// @param nMaxBytes maximum number of bytes to receive.
+    /// @param pBuffer, memory where to receive the data,
+    ///        NULL receives to internal buffer returned with GetData()
+    ///        Non-NULL receives directly there, but GetData() will return WRONG ptr!
     /// @return number of bytes actually received.
     /// @return of zero means the connection has been shutdown on the other side.
     /// @return of -1 means that an error has occurred.
-    virtual int32 Receive(int32 nMaxBytes = 1);
+    virtual int32 Receive(int32 nMaxBytes = 1, uint8 * pBuffer = 0);
 
     /// Attempts to send a block of data on an established connection.
     /// @param pBuf block of data to be sent.

--- a/src/SimpleSocket.h
+++ b/src/SimpleSocket.h
@@ -382,7 +382,7 @@ public:
 
     /// Bind socket to a specific interface when using multicast.
     /// @return true if successfully bound to interface
-    bool BindInterface(uint8 *pInterface);
+    bool BindInterface(const char *pInterface);
 
     /// Gets the timeout value that specifies the maximum number of seconds a
     /// a call to CSimpleSocket::Send waits until it completes.
@@ -448,8 +448,8 @@ public:
 
     /// Returns clients Internet host address as a string in standard numbers-and-dots notation.
     ///  @return NULL if invalid
-    uint8 *GetClientAddr() {
-        return (uint8 *)inet_ntoa(m_stClientSockaddr.sin_addr);
+    const char *GetClientAddr() {
+        return inet_ntoa(m_stClientSockaddr.sin_addr);
     };
 
     /// Returns the port number on which the client is connected.
@@ -460,8 +460,8 @@ public:
 
     /// Returns server Internet host address as a string in standard numbers-and-dots notation.
     ///  @return NULL if invalid
-    uint8 *GetServerAddr() {
-        return (uint8 *)inet_ntoa(m_stServerSockaddr.sin_addr);
+    const char *GetServerAddr() {
+        return inet_ntoa(m_stServerSockaddr.sin_addr);
     };
 
     /// Returns the port number on which the server is connected.

--- a/src/SimpleSocket.h
+++ b/src/SimpleSocket.h
@@ -454,7 +454,7 @@ public:
 
     /// Returns the port number on which the client is connected.
     ///  @return client port number.
-    int16 GetClientPort() {
+    uint16 GetClientPort() {
         return m_stClientSockaddr.sin_port;
     };
 
@@ -466,35 +466,35 @@ public:
 
     /// Returns the port number on which the server is connected.
     ///  @return server port number.
-    int16 GetServerPort() {
+    uint16 GetServerPort() {
         return ntohs(m_stServerSockaddr.sin_port);
     };
 
     /// Get the TCP receive buffer window size for the current socket object.
     /// <br><br>\b NOTE: Linux will set the receive buffer to twice the value passed.
     ///  @return zero on failure else the number of bytes of the TCP receive buffer window size if successful.
-    uint16 GetReceiveWindowSize() {
+    uint32 GetReceiveWindowSize() {
         return GetWindowSize(SO_RCVBUF);
     };
 
     /// Get the TCP send buffer window size for the current socket object.
     /// <br><br>\b NOTE: Linux will set the send buffer to twice the value passed.
     ///  @return zero on failure else the number of bytes of the TCP receive buffer window size if successful.
-    uint16 GetSendWindowSize() {
+    uint32 GetSendWindowSize() {
         return GetWindowSize(SO_SNDBUF);
     };
 
     /// Set the TCP receive buffer window size for the current socket object.
     /// <br><br>\b NOTE: Linux will set the receive buffer to twice the value passed.
     ///  @return zero on failure else the number of bytes of the TCP send buffer window size if successful.
-    uint16 SetReceiveWindowSize(uint16 nWindowSize) {
+    uint32 SetReceiveWindowSize(uint32 nWindowSize) {
         return SetWindowSize(SO_RCVBUF, nWindowSize);
     };
 
     /// Set the TCP send buffer window size for the current socket object.
     /// <br><br>\b NOTE: Linux will set the send buffer to twice the value passed.
     ///  @return zero on failure else the number of bytes of the TCP send buffer window size if successful.
-    uint16 SetSendWindowSize(uint16 nWindowSize) {
+    uint32 SetSendWindowSize(uint32 nWindowSize) {
         return SetWindowSize(SO_SNDBUF, nWindowSize);
     };
 
@@ -523,11 +523,11 @@ protected:
 private:
     /// Generic function used to get the send/receive window size
     ///  @return zero on failure else the number of bytes of the TCP window size if successful.
-    uint16 GetWindowSize(uint32 nOptionName);
+    uint32 GetWindowSize(uint32 nOptionName);
 
     /// Generic function used to set the send/receive window size
     ///  @return zero on failure else the number of bytes of the TCP window size if successful.
-    uint16 SetWindowSize(uint32 nOptionName, uint32 nWindowSize);
+    uint32 SetWindowSize(uint32 nOptionName, uint32 nWindowSize);
 
 
     /// Attempts to send at most nNumItem blocks described by sendVector


### PR DESCRIPTION
please have a look at the changes.

cause of incompatible interface / function prototypes  it might be necessary to change the version number(s) in CMakeLists.txt.
I did not do this, cause i don't know which version would be desired. really change major version?

then, i also replaced the type for most connect/address strings, except for data.
