### PR TITLE
Set VERSION and SONAME version properties from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(clsocket)
 set(BUILD_MAJOR "1")
 set(BUILD_MINOR "4")
 set(BUILD_VERSION "3")
+set(BUILD_VERSION ${BUILD_MAJOR}.${BUILD_MINOR}.${BUILD_VERSION})
 
 include_directories(src)
 
@@ -77,6 +78,9 @@ if(NOT CLSOCKET_DEP_ONLY)
 else()
 
 endif()
+
+set_target_properties(clsocket PROPERTIES VERSION ${BUILD_VERSION}
+                                          SOVERSION ${BUILD_MAJOR})
 
 if(UNIX)
     OPTION(CLSOCKET_EXAMPLES "Build the examples" OFF)


### PR DESCRIPTION
If clsocket is compiled dynamically, this will produce .so files with the version in their name, e.g. libclsocket.so.1.4.3, to which libclsocket.so.1 and libclsocket.so is symlinked to. This means that if anyone wants to use this dynamically, they will nominally be able to better ensure ABI compatibility.

Since the version was already included in the CMake configuration, this is a very simple change.

Since dfhack is linking against clsocket statically, this shouldn't affect it at all, but this change should help anyone who wants to use clsocket as a dynamic library (or build dfhack against a dynamic clsocket for whatever reason).
