### PR TITLE
travis: test against GCC 4.4 instead of 4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ sudo: false
 language: cpp
 matrix:
   include:
-    - env: GCC_VERSION=4.5
+    - env: GCC_VERSION=4.4
       addons:
         apt:
           packages:
-            - gcc-4.5-multilib
-            - g++-4.5-multilib
+            - gcc-4.4-multilib
+            - g++-4.4-multilib
     - env: GCC_VERSION=4.8
       addons:
         apt:


### PR DESCRIPTION
Ubuntu Trusty is now the default image on Travis, and Trusty doesn't
have any GCC 4.5 packages. See
https://bugs.launchpad.net/ubuntu/+source/gcc-4.5/+bug/1028213 and
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=675431 for more
information.