### PR TITLE
MSVC: Fix generation of clsocket.lib

### DIFF
--- a/src/ActiveSocket.h
+++ b/src/ActiveSocket.h
@@ -51,7 +51,7 @@ class CPassiveSocket;
 /// An active socket is used to create a socket which connects to a server.
 /// This type of object would be used when an application needs to send/receive
 /// data from a server.
-class CActiveSocket : public CSimpleSocket {
+class EXPORT CActiveSocket : public CSimpleSocket {
 public:
     friend class CPassiveSocket;
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -250,6 +250,12 @@ extern "C"
   #define FPRINTF  fprintf
 #endif
 
+#ifdef _MSC_VER
+  #define EXPORT __declspec(dllexport)
+#else
+  #define EXPORT
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/PassiveSocket.h
+++ b/src/PassiveSocket.h
@@ -52,7 +52,7 @@
 /// in a similar fashion.  The big difference is that the method
 /// CPassiveSocket::Accept should not be called on the latter two socket
 /// types.
-class CPassiveSocket : public CSimpleSocket {
+class EXPORT CPassiveSocket : public CSimpleSocket {
 public:
     CPassiveSocket(CSocketType type = SocketTypeTcp);
     virtual ~CPassiveSocket() {

--- a/src/SimpleSocket.h
+++ b/src/SimpleSocket.h
@@ -99,7 +99,7 @@
 /// - Socket types
 ///  -# CActiveSocket Class
 ///  -# CPassiveSocket Class
-class CSimpleSocket {
+class EXPORT CSimpleSocket {
 public:
     /// Defines the three possible states for shuting down a socket.
     typedef enum

--- a/src/StatTimer.h
+++ b/src/StatTimer.h
@@ -68,7 +68,7 @@
 
 /// Class to abstract socket communications in a cross platform manner.
 /// This class is designed
-class CStatTimer {
+class EXPORT CStatTimer {
 public:
     CStatTimer()
     {


### PR DESCRIPTION
When building the library on Windows with the Visual Studio compiler, `clsocket.dll` is generated correctly but `clsocket.lib` (the Import Library for use by programs linking with it) isn't generated at all because nothing is exported from the library.

This PR fixes this by adding an `__declspec(dllexport)` clause to the library's classes. This clause is abstracted behind an `EXPORT` conditional define, so that different platforms can use different export behaviors.