### PR TITLE
Fix ignored shutdown mode

### DIFF
--- a/src/SimpleSocket.cpp
+++ b/src/SimpleSocket.cpp
@@ -499,7 +499,7 @@ bool CSimpleSocket::Shutdown(CShutdownMode nShutdown)
 {
     CSocketError nRetVal = SocketEunknown;
 
-    nRetVal = (CSocketError)shutdown(m_socket, CSimpleSocket::Sends);
+    nRetVal = (CSocketError)shutdown(m_socket, nShutdown);
     TranslateSocketError();
 
     return (nRetVal == CSimpleSocket::SocketSuccess) ? true: false;


### PR DESCRIPTION
On shutdown ignored argument of function. This leads to problems for closing socket when accept listening for new connection for example.